### PR TITLE
Removing some unspecified behavior, silencing minor compiler warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# http://editorconfig.org/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{c,h}]
+indent_size = 4
+indent_style = space
+
+[*.html]
+indent_size = 2
+indent_style = tab
+quote_type = double
+
+[*.shp]
+end_of_line = crlf
+
+[Makefile]
+indent_size = 4
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# Default behavior, for when core.autocrlf is not explicitly set
+* text=auto
+
+# Source files
+*.1p           text
+*.c            text diff=cpp  linguist-language=C
+*.F            text           linguist-detectable=false
+*.h            text diff=cpp  linguist-language=C
+*.html         text diff=html
+*.P            text
+*.shp          text eol=crlf
+*_I            text
+.editorconfig  text
+.gitattributes text
+.gitignore     text
+Makefile       text
+
+# Binary files
+*.d     binary linguist-detectable=false
+*.swp   binary
+parse2  binary
+path    binary
+readshp binary
+selpnt  binary
+stack   binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,7 @@
 *.F            text           linguist-detectable=false
 *.h            text diff=cpp  linguist-language=C
 *.html         text diff=html
-*.P            text
+*.P            text           linguist-detectable=false
 *.shp          text eol=crlf
 *_I            text
 .editorconfig  text

--- a/com_add.c
+++ b/com_add.c
@@ -7,6 +7,8 @@
 #include "token.h"
 #include "xwin.h" 	
 
+#define UNUSED(x) (void)(x)
+
 /* 
     Add a component to the current device.
     This routine checks for <component[layer]> or <instance_name>
@@ -15,6 +17,7 @@
 
 int com_add(LEXER *lp, char *arg)		
 {
+    UNUSED(arg);
     TOKEN token;
     char *word;
     int done=0;

--- a/com_add.c
+++ b/com_add.c
@@ -1,3 +1,4 @@
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>		/* for strchr() */
 #include <ctype.h>		/* for toupper */
@@ -22,7 +23,7 @@ int com_add(LEXER *lp, char *arg)
     char *word;
     int done=0;
     int valid_comp=0;
-    int i;
+    size_t i;
     int layer;
 
     int comp;

--- a/com_area.c
+++ b/com_area.c
@@ -8,6 +8,8 @@
 #include "xwin.h" 	
 #include "rubber.h"
 
+#define UNUSED(x) (void)(x)
+
 /* 
     measure the area of a component in the current device.
     AREA <restrictor> { xysel } ... <EOC>
@@ -15,7 +17,7 @@
 
 int com_area(LEXER *lp, char *arg)		
 {
-
+    UNUSED(arg);
     enum {START,NUM1,END} state = START;
 
     TOKEN token;

--- a/com_area.c
+++ b/com_area.c
@@ -1,3 +1,4 @@
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>		/* for strchr() */
 #include <ctype.h>		/* for toupper() */
@@ -25,7 +26,7 @@ int com_area(LEXER *lp, char *arg)
     int debug=0;
     int done=0;
     int valid_comp=0;
-    int i;
+    size_t i;
     DB_DEFLIST *p_best;
     DB_DEFLIST *p_prev = NULL;
     double x1, y1;

--- a/com_change.c
+++ b/com_change.c
@@ -13,6 +13,8 @@
 #include "eprintf.h"
 #include "opt_parse.h"
 
+#define UNUSED(x) (void)(x)
+
 #define MAXBUF 256
 
 /* 
@@ -24,7 +26,7 @@
 
 int com_change(LEXER *lp, char *arg)		
 {
-
+    UNUSED(arg);
     enum {START,NUM1,COM1,NUM2,OPT,NUM3,COM2,NUM4,END} state = START;
 
     TOKEN token;

--- a/com_change.c
+++ b/com_change.c
@@ -1,3 +1,4 @@
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>		/* for strchr() */
 #include <ctype.h>		/* for toupper() */
@@ -38,7 +39,7 @@ int com_change(LEXER *lp, char *arg)
     int retval;
     int valid_comp=0;
     double optval;
-    int i;
+    size_t i;
     DB_DEFLIST *p_best = NULL;
     DB_TAB *p_tab;
     char instname[BUFSIZE];

--- a/com_copy.c
+++ b/com_copy.c
@@ -1,3 +1,4 @@
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>		/* for strchr() */
 #include <ctype.h>		/* for toupper() */
@@ -37,7 +38,7 @@ int com_copy(LEXER *lp, char *arg)
     int debug=0;
     int done=0;
     int valid_comp=0;
-    int i;
+    size_t i;
     DB_DEFLIST *p_best;
     DB_DEFLIST *p_new = NULL;
     int mode=POINT;

--- a/com_copy.c
+++ b/com_copy.c
@@ -8,6 +8,8 @@
 #include "xwin.h" 	
 #include "rubber.h"
 
+#define UNUSED(x) (void)(x)
+
 #define POINT 0
 #define REGION 1
 
@@ -27,7 +29,7 @@ STACK *tmp;
 
 int com_copy(LEXER *lp, char *arg)		
 {
-
+    UNUSED(arg);
     enum {START,NUM1,NUM2,NUM3,NUM4,END} state = START;
 
     TOKEN token;

--- a/com_delete.c
+++ b/com_delete.c
@@ -1,3 +1,4 @@
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>		/* for strchr() */
 #include <ctype.h>		/* for toupper() */
@@ -31,7 +32,7 @@ int com_delete(LEXER *lp, char *arg)
     TOKEN token;
     char *word;
     int valid_comp=0;
-    int i;
+    size_t i;
     DB_DEFLIST *p_best;
     char instname[BUFSIZE];
     char *pinst = (char *) NULL;

--- a/com_delete.c
+++ b/com_delete.c
@@ -8,6 +8,8 @@
 #include "xwin.h" 	
 #include "rubber.h"
 
+#define UNUSED(x) (void)(x)
+
 #define POINT  0
 #define REGION 1
 
@@ -23,7 +25,7 @@ STACK *stack;
 
 int com_delete(LEXER *lp, char *arg)		
 {
-
+    UNUSED(arg);
     enum {START,NUM1,NUM2,END} state = START;
 
     TOKEN token;

--- a/com_distance.c
+++ b/com_distance.c
@@ -7,6 +7,8 @@
 #include "rubber.h"
 #include "rlgetc.h"
 
+#define UNUSED(x) (void)(x)
+
 #define MAXDBUF 20
 
 /*
@@ -22,6 +24,7 @@ void draw_dist();
 
 int com_distance(LEXER *lp, char *arg)
 {
+    UNUSED(arg);
     enum {START,NUM1,NUM2,END} state = START;
 
     double x2,y2;

--- a/com_equate.c
+++ b/com_equate.c
@@ -8,10 +8,13 @@
 #include "rlgetc.h"
 #include "equate.h"
 
+#define UNUSED(x) (void)(x)
+
 #define MAXBUF 128
 
 int com_equate(LEXER* lp, char *arg)	   /* define properties of each layer */
 {
+    UNUSED(arg);
     TOKEN token;
     int done=0;
     char *word;

--- a/com_ident.c
+++ b/com_ident.c
@@ -7,6 +7,8 @@
 #include "rubber.h"
 #include "rlgetc.h"
 
+#define UNUSED(x) (void)(x)
+
 #define POINT  0
 #define REGION 1
 
@@ -32,6 +34,7 @@ STACK *stack;
 
 int com_identify(LEXER *lp, char *arg)
 {
+    UNUSED(arg);
     enum {START,NUM1,NUM2,END} state = START;
 
     TOKEN token;

--- a/com_ident.c
+++ b/com_ident.c
@@ -1,3 +1,4 @@
+#include <stddef.h>
 #include <ctype.h>
 #include <string.h>
 
@@ -44,7 +45,7 @@ int com_identify(LEXER *lp, char *arg)
     double area;
     DB_DEFLIST *p_prev = NULL;
     char *pinst = (char *) NULL;
-    int i;
+    size_t i;
     int debug=0;
     int mode=POINT;
     int done=0;

--- a/com_move.c
+++ b/com_move.c
@@ -1,3 +1,4 @@
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>		/* for strchr() */
 #include <ctype.h>		/* for toupper() */
@@ -36,7 +37,7 @@ int com_move(LEXER *lp, char *arg)
     int debug=0;
     int done=0;
     int valid_comp=0;
-    int i;
+    size_t i;
     DB_DEFLIST *p_best;
     DB_DEFLIST *p_new = NULL;
     int mode=POINT;

--- a/com_move.c
+++ b/com_move.c
@@ -8,6 +8,8 @@
 #include "xwin.h" 	
 #include "rubber.h"
 
+#define UNUSED(x) (void)(x)
+
 #define POINT 0
 #define REGION 1
 
@@ -26,7 +28,7 @@ STACK *tmp;
 
 int com_move(LEXER *lp, char *arg)		
 {
-
+    UNUSED(arg);
     enum {START,NUM1,NUM2,NUM3,NUM4,END} state = START;
 
     TOKEN token;

--- a/com_point.c
+++ b/com_point.c
@@ -3,6 +3,8 @@
 #include "token.h"
 #include "rlgetc.h"
 
+#define UNUSED(x) (void)(x)
+
 /*
  *
  * POI xypnt ...
@@ -15,6 +17,7 @@ static double x1, y1;
 
 int com_point(LEXER *lp, char *arg)
 {
+    UNUSED(arg);
     enum {START,NUM1,END} state = START;
 
     int done=0;

--- a/com_purge.c
+++ b/com_purge.c
@@ -8,10 +8,13 @@
 #include "xwin.h" 	
 #include "rubber.h"
 
+#define UNUSED(x) (void)(x)
+
 int com_purge(lp, arg)		/* remove device from memory and disk */
 LEXER *lp;
 char *arg;
 {
+    UNUSED(arg);
     TOKEN token;
     int done=0;
     char *word;

--- a/com_shell.c
+++ b/com_shell.c
@@ -14,6 +14,7 @@
 #include "rlgetc.h"
 #include "ev.h"
 
+#define UNUSED(x) (void)(x)
 
 typedef void (*sighandler_t)(int);
 
@@ -56,6 +57,7 @@ int pig_system(char *s) {
 
 int com_echo(LEXER *lp, char *arg)	/* echo variables */
 {
+    UNUSED(arg);
     char *word;	
     TOKEN token;
     int debug=0;
@@ -72,6 +74,7 @@ int com_echo(LEXER *lp, char *arg)	/* echo variables */
 
 int com_define(LEXER *lp, char *arg)	/* set macro definition */
 {
+    UNUSED(arg);
     int debug = 0;
     char *word;
     char var[128];
@@ -111,6 +114,7 @@ int com_define(LEXER *lp, char *arg)	/* set macro definition */
 
 int com_set(LEXER *lp, char *arg)	/* set environment variables */
 {
+    UNUSED(arg);
     int debug = 0;
     char *word;
     char var[128];
@@ -175,6 +179,7 @@ int com_set(LEXER *lp, char *arg)	/* set environment variables */
 
 int com_shell(LEXER *lp, char *arg)		/* run a program from within the editor */
 {
+    UNUSED(arg);
     int debug = 0;
     // char *shell;
     char cmd[1024];

--- a/com_show.c
+++ b/com_show.c
@@ -7,6 +7,8 @@
 #include "token.h"
 #include "rlgetc.h"
 
+#define UNUSED(x) (void)(x)
+
 /*
 SHOW {+|-|#}[EACILN0PRT]<layer>
 
@@ -30,6 +32,7 @@ SHOW {+|-|#}[EACILN0PRT]<layer>
 
 int com_show(LEXER *lp, char *arg)		/* define which kinds of things to display */
 {
+    UNUSED(arg);
     TOKEN token;
     int done=0;
     char *word;

--- a/com_smash.c
+++ b/com_smash.c
@@ -8,6 +8,8 @@
 #include "rubber.h"
 #include "rlgetc.h"
 
+#define UNUSED(x) (void)(x)
+
 #define POINT  0
 #define REGION 1
 
@@ -89,6 +91,7 @@ void smashrep(DB_DEFLIST *p_best) {
 
 int com_smash(LEXER *lp, char *arg)
 {
+    UNUSED(arg);
     enum {START,NUM1,NUM2,END} state = START;
 
     int done=0;

--- a/com_stretch.c
+++ b/com_stretch.c
@@ -9,6 +9,8 @@
 #include "rlgetc.h"
 #include "lock.h"
 
+#define UNUSED(x) (void)(x)
+
 #define POINT  0
 #define REGION 1
 
@@ -48,6 +50,7 @@ DB_DEFLIST *p_best;
 
 int com_stretch(LEXER *lp, char *arg)
 {
+    UNUSED(arg);
     enum {START,
           NUM1,	/* xysel, xyll: x1, yy1 */
 	  NUM2,	/* xyur:        x2, y2  */

--- a/com_stretch.c
+++ b/com_stretch.c
@@ -1,3 +1,4 @@
+#include <stddef.h>
 #include <ctype.h>
 #include <math.h>
 #include <string.h>
@@ -70,7 +71,7 @@ int com_stretch(LEXER *lp, char *arg)
     double *xselold,*yselold;
     double *xselfirst,*yselfirst;
     char instname[BUFSIZE];
-    int i;
+    size_t i;
 
     char *pinst = (char *) NULL;
     int mode=POINT;

--- a/com_undo.c
+++ b/com_undo.c
@@ -7,6 +7,8 @@
 #include "token.h"
 #include "xwin.h" 	
 
+#define UNUSED(x) (void)(x)
+
 //
 // This is piglet's undo/redo facility.
 //
@@ -43,6 +45,7 @@
 
 int com_undo(LEXER *lp, char *arg)		
 {
+    UNUSED(arg);
     DB_DEFLIST *a;
 
     /* check that we are editing a rep */
@@ -74,6 +77,7 @@ int com_undo(LEXER *lp, char *arg)
 
 int com_redo(LEXER *lp, char *arg)		
 {
+    UNUSED(arg);
     DB_DEFLIST *a;
 
     /* check that we are editing a rep */

--- a/com_window.c
+++ b/com_window.c
@@ -8,6 +8,8 @@
 #include "eprintf.h"
 #include "equate.h"
 
+#define UNUSED(x) (void)(x)
+
 static double x1, y1;
 int fit=0;		/* don't fit */
 int nest=9;		/* default nesting level */
@@ -20,6 +22,7 @@ int do_win();
 
 int com_window(LEXER *lp, char *arg)
 {
+    UNUSED(arg);
     enum {START,NUM1,COM1,NUM2,NUM3,COM2,NUM4,END} state = START;
 
     double scale=1.0;	/* default scale */
@@ -182,7 +185,7 @@ int com_window(LEXER *lp, char *arg)
 }
 
 int do_win(LEXER *lp, int n, double x1, double y1, double x2, double y2, double scale) {
-
+    UNUSED(lp);
     extern int fit, nest;
     double dx, dy, xmin, ymin, xmax, ymax, tmp;
     int debug=0;

--- a/com_wrap.c
+++ b/com_wrap.c
@@ -1,3 +1,4 @@
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>		/* for strchr() */
 #include <ctype.h>		/* for toupper() */
@@ -31,7 +32,7 @@ int com_wrap(LEXER *lp, char *arg)
     char *word;
     int debug=0;
     int valid_comp=0;
-    int i;
+    size_t i;
     DB_DEFLIST *p_best;
     DB_DEFLIST *p_new;
     DB_TAB *newrep;

--- a/com_wrap.c
+++ b/com_wrap.c
@@ -8,6 +8,8 @@
 #include "xwin.h" 	
 #include "rubber.h"
 
+#define UNUSED(x) (void)(x)
+
 static double x1, y1, x2, y2, x3, y3;
 void wrap_draw_box();
 STACK *stack;
@@ -21,7 +23,7 @@ static int instcounter=0;	/* used for generating uniq instance names */
 
 int com_wrap(LEXER *lp, char *arg)		
 {
-
+    UNUSED(arg);
     enum {START,NUM1,NUM2,NUM3,END} state = START;
 
     int done=0;

--- a/db.c
+++ b/db.c
@@ -1,5 +1,6 @@
 #include <sys/stat.h>	/* for mkdir() */
 #include <sys/types.h>	/* for mkdir() */
+#include <stddef.h>
 #include <stdio.h>
 #include <math.h>
 #include <string.h>	/* for strnlen... */
@@ -1517,7 +1518,7 @@ void digestdouble(double a) {
     extern int digestvalue;
     unsigned char *p;
     int debug=0;
-    int i;
+    size_t i;
 
     if (debug) printf("(%12.12g)", a);
     p = (unsigned char *) &a;

--- a/db.c
+++ b/db.c
@@ -3382,7 +3382,7 @@ void show_list(DB_TAB *currep, int layer)
 
 int getbits(unsigned int x, unsigned int p, unsigned int n)	
 {
-    return((x >> (p+1-n)) & ~(~0 << n));
+    return((x >> (p+1-n)) & ~((unsigned int)~0 << n));
 }
 
 void show_init(DB_TAB *currep) { /* set everyone visible, but RO */

--- a/db.c
+++ b/db.c
@@ -18,6 +18,8 @@
 #include "ev.h"
 #include "postscript.h"
 
+#define UNUSED(x) (void)(x)
+
 #define EPS 1e-6
 #define MAXBUF 128	// maximum escaped text string
 
@@ -966,9 +968,9 @@ int db_arc_smash(DB_TAB *cell, XFORM *xform, int ortho)
 * smashing currently unimplemented
 * FIXME: include process file if process !=0 
 */
-
 int db_def_archive(DB_TAB *sp, int smash, int process) 
 {
+    UNUSED(process);
     FILE *fp;
     char buf[MAXFILENAME];
     int err=0;
@@ -1535,6 +1537,7 @@ void digeststr(char *s) {
 }
 
 void digestopts(OPTS *opts, char *optstring) {
+    UNUSED(optstring);
     digestdouble(opts->font_size);
     digestint(opts->mirror);
     digestint(opts->font_num);
@@ -3041,6 +3044,9 @@ void do_line(DB_DEFLIST *def, BOUNDS *bb, int mode)
 
 void do_oval(DB_DEFLIST *def, BOUNDS *bb, int mode)
 {
+    UNUSED(def);
+    UNUSED(bb);
+    UNUSED(mode);
     // NUM x1,y1,x2,y2,x3,y3;
 
     /* printf("# rendering oval (not implemented)\n"); */

--- a/draw.c
+++ b/draw.c
@@ -2410,7 +2410,7 @@ void emit(
 	    R_to_V(&xp, &yp);
 
 	    bb->xmax += (double) pickcheck(xxold, yyold, x, y, xp, yp, 3.0);
-	} else if ((mode == D_RUBBER)) { /* xor rubber band drawing */
+	} else if (mode == D_RUBBER) { /* xor rubber band drawing */
 	    if (drawon) {
 		if (X && (nseg > 1)) {
 		    xwin_rubber_line((int)xxold,(int)yyold,(int)x,(int)y);

--- a/draw.c
+++ b/draw.c
@@ -11,6 +11,8 @@
 #include "ev.h"
 #include "readfont.h"
 
+#define UNUSED(x) (void)(x)
+
 #define FUZZBAND 0.01	/* how big the fuzz around lines is as */
                         /* a fraction of minimum window dimension */
 			/* for the purpose of picking objects */
@@ -2024,6 +2026,8 @@ int db_render(
 
 void startpoly(BOUNDS *bb, int mode)
 {
+    UNUSED(bb);
+    UNUSED(mode);
     filled_object = 1;		/* global for managing polygon filling */
     n_poly_points = 0;		/* number of points in filled polygon */
     // if (!X) {
@@ -2570,6 +2574,8 @@ int pickcheck(
 
 void jump(BOUNDS *bb, int mode) 
 {
+    UNUSED(bb);
+    UNUSED(mode);
     nseg=0;  
     filled_object = 0;		/* automatically close polygon */
 }

--- a/equate.c
+++ b/equate.c
@@ -143,7 +143,7 @@ void equate_toggle_override(int layer) {
         printf("invalid layer %d\n", layer);
     }
 }
-int equate_get_override(layer) {	
+int equate_get_override(int layer) {
     if (layer < MAX_LAYER && layer >= 0) {
         return(equates[layer].flags.override);
     }

--- a/lex.c
+++ b/lex.c
@@ -25,6 +25,8 @@
 #include "postscript.h"
 #include "readshpfont.h"
 
+#define UNUSED(x) (void)(x)
+
 int readin();
 
 /* The names of functions that actually do the manipulation. */
@@ -190,6 +192,7 @@ void sighandler(); 	/* catch signal */
 
 int main(int argc, char **argv)
 {
+    UNUSED(argc);
     LEXER *lp;		/* lexer struct for main cmd loop */
     int err=0;
     char buf[128];
@@ -598,6 +601,7 @@ int add_arc(LEXER *lp, int *layer)
 
 int add_oval(LEXER *lp, int *layer)
 {
+    UNUSED(layer);
     printf("in add_oval (unimplemented)\n");
     token_flush_EOL(lp);
     return(1);
@@ -607,6 +611,7 @@ int add_oval(LEXER *lp, int *layer)
 
 int com_archive(LEXER *lp, char *arg)   /* create archive file of currep */
 {
+    UNUSED(arg);
     TOKEN token;
     int done=0;
     char *word;
@@ -680,6 +685,7 @@ int com_archive(LEXER *lp, char *arg)   /* create archive file of currep */
 
 int com_background(LEXER *lp, char *arg)	/* use device for background overlay */
 {
+    UNUSED(arg);
     TOKEN token;
     int done=0;
     char buf[128];
@@ -745,6 +751,7 @@ int com_background(LEXER *lp, char *arg)	/* use device for background overlay */
 
 int com_bye(LEXER *lp, char *arg)		/* terminate edit session */
 {
+    UNUSED(arg);
     /* The user wishes to quit using this program */
     /* two consecutive BYE requests will force an exit */
     /* Just set quit_now non-zero. */
@@ -775,6 +782,8 @@ int com_bye(LEXER *lp, char *arg)		/* terminate edit session */
 
 int com_date(LEXER *lp, char *arg)		/* print date and time to console */
 {
+    UNUSED(lp);
+    UNUSED(arg);
     char buf[MAXFILENAME]; 
     time_t time_now;
 
@@ -790,6 +799,7 @@ int com_date(LEXER *lp, char *arg)		/* print date and time to console */
 
 int com_display(LEXER *lp, char *arg)	/* turn the display on or off */
 {
+    UNUSED(arg);
     TOKEN token;
     int done=0;
     // char buf[128];
@@ -854,6 +864,7 @@ int com_display(LEXER *lp, char *arg)	/* turn the display on or off */
 
 int com_dump(LEXER *lp, char *arg)	/* dump graphics window to file or printer */
 {
+    UNUSED(arg);
     TOKEN token;
     int done=0;
     char cmd[256];
@@ -990,6 +1001,7 @@ int com_dump(LEXER *lp, char *arg)	/* dump graphics window to file or printer */
 
 int com_exit(LEXER *lp, char *arg)		/* leave an EDIT, PROCESS, SEARCH subsystem */
 {
+    UNUSED(arg);
     int debug=0;
     int editlevel;
     static int linenumber;	/* remember last request so that */
@@ -1034,6 +1046,7 @@ int com_exit(LEXER *lp, char *arg)		/* leave an EDIT, PROCESS, SEARCH subsystem 
 
 int com_files(LEXER *lp, char *arg)		/* purge named files */
 {
+    UNUSED(arg);
     TOKEN token;
     int done=0;
     // char buf[128];
@@ -1070,6 +1083,7 @@ int com_files(LEXER *lp, char *arg)		/* purge named files */
 
 int com_fsize(LEXER *lp, char *arg)	/* Set the default font size for text and notes */
 {
+    UNUSED(arg);
     TOKEN token;
     int done=0;
     int fsize;
@@ -1133,6 +1147,7 @@ int com_fsize(LEXER *lp, char *arg)	/* Set the default font size for text and no
 
 int com_grid(LEXER *lp, char *arg)		/* change or redraw grid */
 {
+    UNUSED(arg);
     TOKEN token;
     int done=0;
     // char buf[128];
@@ -1282,6 +1297,7 @@ int com_grid(LEXER *lp, char *arg)		/* change or redraw grid */
 
 int com_group(LEXER *lp, char *arg)	/* create a device from existing components */
 {
+    UNUSED(lp);
     printf("    com_group %s\n", arg);
     return (0);
 }
@@ -1290,6 +1306,7 @@ int com_group(LEXER *lp, char *arg)	/* create a device from existing components 
 
 int com_help(LEXER *lp, char *arg)
 {
+    UNUSED(arg);
     TOKEN token;
     int done=0;
     char *word;
@@ -1417,6 +1434,7 @@ int readin(		/* work routine for com_input */
 
 int com_input(LEXER *lp, char *arg)		/* take command input from a file */
 {
+    UNUSED(arg);
     TOKEN token;
     char buf[MAXFILENAME];
     char *word;
@@ -1470,12 +1488,15 @@ int com_input(LEXER *lp, char *arg)		/* take command input from a file */
 
 int com_interrupt(LEXER *lp, char *arg)	/* interrupt an ADD to issue another command */
 {
+    UNUSED(lp);
+    UNUSED(arg);
     printf("    com_interrupt\n");
     return (0);
 }
 
 int com_layer(LEXER *lp, char *arg)		/* set a default layer number */
 {
+    UNUSED(arg);
     extern int def_layer;
 
     TOKEN token;
@@ -1534,6 +1555,7 @@ int com_layer(LEXER *lp, char *arg)		/* set a default layer number */
 
 int com_level(LEXER *lp, char *arg)	/* set the logical level of the current device */
 {
+    UNUSED(arg);
     TOKEN token;
     int done=0;
     int level;
@@ -1592,7 +1614,7 @@ int com_level(LEXER *lp, char *arg)	/* set the logical level of the current devi
 
 int com_list(LEXER *lp, char *arg)	/* list information about the current environment */
 {
-
+    UNUSED(arg);
     if (lp->mode == EDI) {
 	if (currep != NULL) {
 	    db_list(currep);
@@ -1613,6 +1635,7 @@ int com_list(LEXER *lp, char *arg)	/* list information about the current environ
 
 int com_lock(LEXER *lp, char *arg)		/* set the default lock angle */
 {
+    UNUSED(arg);
     TOKEN token;
     int done=0;
     double angle;
@@ -1673,6 +1696,7 @@ int com_lock(LEXER *lp, char *arg)		/* set the default lock angle */
 
 int com_eval(LEXER *lp, char *arg)		/* evaluate a MACRO */
 {
+    UNUSED(arg);
     TOKEN token;
     char *word;
     char buf[6];
@@ -1702,6 +1726,7 @@ int com_eval(LEXER *lp, char *arg)		/* evaluate a MACRO */
 
 int com_macro(LEXER *lp, char *arg)		/* enter the MACRO subsystem */
 {
+    UNUSED(arg);
     printf("    com_macro\n");
     if (lp->mode == MAIN) {
 	lp->mode = MAC;
@@ -1713,6 +1738,8 @@ int com_macro(LEXER *lp, char *arg)		/* enter the MACRO subsystem */
 
 int com_menu(LEXER *lp, char *arg)		/* change or save the current menu */
 {
+    UNUSED(lp);
+    UNUSED(arg);
     printf("    com_menu\n");
     return (0);
 }
@@ -1722,6 +1749,7 @@ int com_menu(LEXER *lp, char *arg)		/* change or save the current menu */
 
 int com_plot(LEXER *lp, char *arg)		/* make a postcript plot of the current device */
 {
+    UNUSED(arg);
     TOKEN token;
     int done=0;
     char *word;
@@ -1861,6 +1889,7 @@ int com_plot(LEXER *lp, char *arg)		/* make a postcript plot of the current devi
 
 int com_process(LEXER *lp, char *arg)	/* enter the PROCESS subsystem */
 {
+    UNUSED(arg);
     printf("    com_process\n");
     if (lp->mode == MAIN) {
 	lp->mode = PRO;
@@ -1872,6 +1901,7 @@ int com_process(LEXER *lp, char *arg)	/* enter the PROCESS subsystem */
 
 int com_retrieve(LEXER *lp, char *arg)	/* read commands from an ARCHIVE file */
 {
+    UNUSED(arg);
     TOKEN token;
     char buf[MAXFILENAME];
     char *word;
@@ -2029,6 +2059,7 @@ int com_save(LEXER *lp, char *arg)	/* save the current file or device to disk */
 
 int com_search(LEXER *lp, char *arg)		/* modify the search path */
 {
+    UNUSED(arg);
     printf("    com_search\n");
 
     if (lp->mode == MAIN) {
@@ -2046,12 +2077,16 @@ int com_search(LEXER *lp, char *arg)		/* modify the search path */
 
 int com_split(LEXER *lp, char *arg)		/* cut a component into two halves */
 {
+    UNUSED(lp);
+    UNUSED(arg);
     printf("    com_split\n");
     return (0);
 }
 
 int com_step(LEXER *lp, char *arg)	/* copy a component in an array fashion */
 {
+    UNUSED(lp);
+    UNUSED(arg);
     printf("    com_step\n");
     return (0);
 }
@@ -2061,6 +2096,8 @@ int com_step(LEXER *lp, char *arg)	/* copy a component in an array fashion */
 
 int com_time(LEXER *lp, char *arg)		/* print the system time to console */
 {
+    UNUSED(lp);
+    UNUSED(arg);
     char buf[MAXFILENAME]; 
     static time_t time_old = 0;
     static time_t time_now = 0;
@@ -2079,12 +2116,15 @@ int com_time(LEXER *lp, char *arg)		/* print the system time to console */
 
 int com_trace(LEXER *lp, char *arg)		/* highlight named signals */
 {
+    UNUSED(lp);
+    UNUSED(arg);
     printf("    com_trace\n");
     return (0);
 }
 
 int com_tslant(LEXER *lp, char *arg)	/* set the default font slant for italic text and notes */
 {
+    UNUSED(arg);
     TOKEN token;
     int done=0;
     int slant;
@@ -2146,6 +2186,8 @@ int com_tslant(LEXER *lp, char *arg)	/* set the default font slant for italic te
 
 int old_com_units(LEXER *lp, char *arg)	/* set editor resolution and user unit type */
 {
+    UNUSED(lp);
+    UNUSED(arg);
     // FIXME: currently the grid resolution is hardwired in com_grid() in the UNITS variable;
     // com_units should be able to set and query the value here
     
@@ -2155,6 +2197,7 @@ int old_com_units(LEXER *lp, char *arg)	/* set editor resolution and user unit t
 
 int com_units(LEXER *lp, char *arg)		/* set a default layer number */
 {
+    UNUSED(arg);
     extern int def_units;
 
     TOKEN token;
@@ -2213,6 +2256,8 @@ int com_units(LEXER *lp, char *arg)		/* set a default layer number */
 
 int com_version(LEXER *lp, char *arg)	/* identify the version number of program */
 {
+    UNUSED(lp);
+    UNUSED(arg);
     printf("    com_version: %s\n", VERSION);
     return (0);
 }

--- a/lex.c
+++ b/lex.c
@@ -1,4 +1,5 @@
 #define _GNU_SOURCE
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>		/* for strchr() */
 #include <ctype.h>		/* for toupper */
@@ -1312,7 +1313,7 @@ int com_help(LEXER *lp, char *arg)
     char *word;
     int debug=0;
     register int i;
-    int j;
+    size_t j;
     int printed = 0;
     int size;
     char cmd[128];

--- a/postscript.c
+++ b/postscript.c
@@ -567,7 +567,7 @@ void ps_end_line()
 
 void ps_flush() {
     if (in_line) {
-    	ps_end_line(fp);
+    	ps_end_line();
     } 
     in_line=0;
 }
@@ -588,7 +588,7 @@ void ps_start_line(double x1, double y1, int filled)
     if (debug) printf("ps_start_line:\n");
 
     if (in_line) {
-    	ps_end_line(fp);
+    	ps_end_line();
     } 
     in_line++;
 
@@ -716,7 +716,7 @@ void ps_postamble()
 
     if (debug) printf("ps_postamble:\n");
     if (in_line) {
-    	ps_end_line(fp);
+    	ps_end_line();
 	in_line=0;
     } 
     if (outputtype == POSTSCRIPT) {

--- a/postscript.c
+++ b/postscript.c
@@ -436,7 +436,7 @@ void ps_preamble(
 	fprintf(fp,"/tr {translate} bind def\n");
 
 	fprintf(fp,"%% start stipple patterns\n");
-	int i,j; char *ps;
+	int i,j; unsigned char *ps;
 	for (i=0;(ps=get_stipple_bits(i))!=NULL;i++) {
 	    fprintf(fp,"/p%d {\n",i);
 	    fprintf(fp,".5 .5 scale 8 8 true  matrix {<");

--- a/readmenu.c
+++ b/readmenu.c
@@ -1,4 +1,5 @@
 #define _GNU_SOURCE
+#include <stddef.h>
 #include <stdio.h>
 
 #include "readmenu.h"
@@ -117,7 +118,7 @@ int getcolor(
     char *s,  	/* a color string */
     int k	/* index of color */
 ) {
-    int i;
+    size_t i;
     int n=0;
     int c;
     for (i=0; i<=strlen(s); i++) {

--- a/readshpfont.c
+++ b/readshpfont.c
@@ -34,6 +34,7 @@ int nfonts=0;
 FONT *fonttab[MAXFONTS];
 
 typedef enum {
+    READSHPFONT_UNUSED = -1, /* forces enum to be a signed integral type */
     EOL,
     LP,				// '(' left paren
     RP,				// ')' right paren

--- a/shpfonts/parse2.c
+++ b/shpfonts/parse2.c
@@ -15,6 +15,7 @@
 unsigned char *glyphtab[258];		// pointers to byte arrays
 
 typedef enum {
+    PARSE2_UNUSED = -1, /* forces enum to be a signed integral type */
     EOL,
     LP,				// '(' left paren
     RP,				// ')' right paren

--- a/shpfonts/readshp.c
+++ b/shpfonts/readshp.c
@@ -31,6 +31,7 @@ int nfonts=0;
 FONT *fonttab[MAXFONTS];
 
 typedef enum {
+    READSHP_UNUSED = -1, /* forces enum to be a signed integral type */
     EOL,
     LP,				// '(' left paren
     RP,				// ')' right paren

--- a/stipple.c
+++ b/stipple.c
@@ -15,7 +15,7 @@ extern Window win;
 
 Pixmap stipple[MAXSTIP];
 
-char stip_src[MAXSTIP][STIPW] = {
+unsigned char stip_src[MAXSTIP][STIPW] = {
 
     /* EQU :F1 solid fill */
     {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, /* solid fill */
@@ -100,7 +100,7 @@ void init_stipples() {
     int i,j;
     unsigned char a;
     for (i=0; i<50; i++) {	/* deterministic stipples */
-	stipple[i] = XCreateBitmapFromData(dpy, win, stip_src[i], 
+	stipple[i] = XCreateBitmapFromData(dpy, win, (const char *)stip_src[i], 
 	    (unsigned int) STIPW, (unsigned int) STIPH);
     }
     for (; i<MAXSTIP; i++) {	/* make random stipples */
@@ -112,7 +112,7 @@ void init_stipples() {
 	    /* a &= (unsigned char) (drand48()*255.0); */
 	    stip_src[i][j] = (unsigned char) a;
 	}
-	stipple[i] = XCreateBitmapFromData(dpy, win, stip_src[i],
+	stipple[i] = XCreateBitmapFromData(dpy, win, (const char *)stip_src[i],
 	    (unsigned int) STIPW, (unsigned int) STIPH);
     }
 }
@@ -125,7 +125,7 @@ int get_stipple_index(int fill, int pen) {
    }
 }
 
-char *get_stipple_bits(int i) {
+unsigned char *get_stipple_bits(int i) {
 
    if (i >= MAXSTIP-1) {
       return NULL;

--- a/token.h
+++ b/token.h
@@ -1,6 +1,7 @@
 #define BUFSIZE 1024
 
 typedef enum {
+    TOKEN_UNUSED = -1, /* forces enum to be a signed integral type */
     IDENT, 	/* identifier */			
     CMD,	/* command (an ident found in commands[]) */
     QUOTE, 	/* quoted string */

--- a/xwin.c
+++ b/xwin.c
@@ -86,7 +86,7 @@ static int moved=0;
 
 #define icon_bitmap_width 20
 #define icon_bitmap_height 20
-static char icon_bitmap_bits[] = {
+static unsigned char icon_bitmap_bits[] = {
     0x60, 0x00, 0x01, 0xb0, 0x00, 0x07, 0x0c, 0x03, 0x00, 0x04, 0x04, 0x00,
     0xc2, 0x18, 0x00, 0x03, 0x30, 0x00, 0x01, 0x60, 0x00, 0xf1, 0xdf, 0x00,
     0xc1, 0xf0, 0x01, 0x82, 0x01, 0x00, 0x02, 0x03, 0x00, 0x02, 0x0c, 0x00,
@@ -229,7 +229,7 @@ int initX()
     if (top_width < menu_width*2) {
        top_width = menu_width*2;
     }
-    if (top_height < menu_height) {
+	if (top_height < menu_height) {
        top_height = menu_height;
     }
 
@@ -294,7 +294,7 @@ int initX()
 
     /* Create pixmap of depth 1 (bitmap) for icon */
     icon_pixmap = XCreateBitmapFromData(dpy, win,
-        icon_bitmap_bits, icon_bitmap_width, icon_bitmap_height);
+        (const char *)icon_bitmap_bits, icon_bitmap_width, icon_bitmap_height);
     
     size_hints->flags = PPosition | PSize | PMinSize;
     size_hints->min_width =  300;

--- a/xwin.c
+++ b/xwin.c
@@ -231,7 +231,7 @@ int initX()
     if (top_width < menu_width*2) {
        top_width = menu_width*2;
     }
-	if (top_height < menu_height) {
+	if ((menu_height > 0) && (top_height < (unsigned int)menu_height)) {
        top_height = menu_height;
     }
 

--- a/xwin.c
+++ b/xwin.c
@@ -26,6 +26,8 @@
 #include "path.h"
 #include "ev.h"
 
+#define UNUSED(x) (void)(x)
+
 extern void do_win();
 void xwin_window_parms_only();
 
@@ -1948,6 +1950,7 @@ int dump_window(
     unsigned int height,
     char *cmd
 ) {
+    UNUSED(gc);
     XImage *xi;
     int x, y;
     unsigned long pixel;

--- a/xwin.c
+++ b/xwin.c
@@ -376,7 +376,7 @@ int initX()
     xwin_grid_pts(10.0, 10.0, 2.0, 2.0, 0.0, 0.0);
     xwin_grid_color(1);
     xwin_grid_state(G_ON);
-    xwin_display_set_state(G_ON);
+    xwin_display_set_state(D_ON);
     xwin_window_set(-100.0,-100.0, 100.0, 100.0);
 
     /* initialize unitytransform */

--- a/xwin.h
+++ b/xwin.h
@@ -56,6 +56,6 @@ void xwin_set_title(char *title);
 extern char version[];
 extern void init_stipples();
 extern int get_stipple_index(int fill, int pen);
-extern char *get_stipple_bits(int i);
+extern unsigned char *get_stipple_bits(int i);
 extern const char * xwin_ps_dashes(int line);
 extern const char * get_hpgl_fill(int line);


### PR DESCRIPTION
A quick summary of the changes:

These are to prevent implementation-defined or unspecified behavior:

- Using signed types for enums where negative values are meaningful
- Using unsigned chars for byte-types where bitwise operations are meaningful
- Changing some array index variables from type int to size_t
- Left-shifting only unsigned types

These are to silence some pesky compiler warnings:

- Marking unused function arguments with the macro UNUSED
- Adding explicit 'int' type to functions arguments where it would otherwise be inferred by default
- Avoiding casts between different enum types
- Removing extraneous parentheses and unnecessary arguments in function calls

These are some new files:

- .gitattributes, to provide some hints to the user's difftool and to GitHub's language-detection
- .editorconfig, to enforce coding styles for editors that support it (I used dummy values for C indentation size and style, feel free to change to your own preferred values)