### PR TITLE
renaming `strtonum` to `str2num` to avoid conflict with BSD libc

### DIFF
--- a/readshpfont.c
+++ b/readshpfont.c
@@ -94,7 +94,7 @@ void shp_jump(BOUNDS *bb, int mode) {
    // printf("jump\n");
 }
 
-int strtonum(char *str) {
+int str2num(char *str) {
     int i;
     int sign=1.0;
     int val;
@@ -657,7 +657,7 @@ int shp_loadfont(char *path, int position)
 	    break;
 	case 1:		// get glyph num
 	    if (token == VAL) {
-		glyphnum = strtonum(tp);
+		glyphnum = str2num(tp);
 	    } else if (token == WORD) {
 		glyphnum = 0;
 	    } else {
@@ -672,7 +672,7 @@ int shp_loadfont(char *path, int position)
 		fprintf(stderr, "parse error in state %d\n", state);
 		exit(1);
 	    }
-	    numbytes = strtonum(tp);
+	    numbytes = str2num(tp);
 	    if (debug) printf("got numbytes %d\n", numbytes);
 	    state = 3;
 	    break;
@@ -699,7 +699,7 @@ int shp_loadfont(char *path, int position)
 	    break;
 	case 5:
 	    if (token == VAL) {
-	       bytecode[count]=strtonum(tp);
+	       bytecode[count]=str2num(tp);
 	       if (debug) printf("    %d %d %d\n", count, numbytes, bytecode[count]);
 	       count++; 
 	    } else if (token == EOL) {

--- a/shpfonts/parse2.c
+++ b/shpfonts/parse2.c
@@ -47,7 +47,7 @@ char *estrdup(const char *s);
 void eatwhite();
 int token_unget(TOKEN token, char *word);
 
-int strtonum(char *str) {
+int str2num(char *str) {
     int i;
     int sign=1.0;
     int val;
@@ -541,7 +541,7 @@ int main()
 	    break;
 	case 1:		// get glyph num
 	    if (token == NUM) {
-		glyphnum = strtonum(tp);
+		glyphnum = str2num(tp);
 	    } else if (token == WORD) {
 		glyphnum = 0;
 	    } else {
@@ -556,7 +556,7 @@ int main()
 		fprintf(stderr, "parse error in state %d\n", state);
 		exit(1);
 	    }
-	    numbytes = strtonum(tp);
+	    numbytes = str2num(tp);
 	    if (debug) printf("got numbytes %d\n", numbytes);
 	    state = 3;
 	    break;
@@ -579,7 +579,7 @@ int main()
 	    break;
 	case 5:
 	    if (token == NUM) {
-	       bytecode[count]=strtonum(tp);
+	       bytecode[count]=str2num(tp);
 	       if (debug) printf("    %d %d %d\n", count, numbytes, bytecode[count]);
 	       count++; 
 	    } else if (token == EOL) {

--- a/shpfonts/readshp.c
+++ b/shpfonts/readshp.c
@@ -82,7 +82,7 @@ void shpjump(int mode) {
    printf("jump\n");
 }
 
-int strtonum(char *str) {
+int str2num(char *str) {
     int i;
     int sign=1.0;
     int val;
@@ -624,7 +624,7 @@ int shp_loadfont(char *path)
 	    break;
 	case 1:		// get glyph num
 	    if (token == NUM) {
-		glyphnum = strtonum(tp);
+		glyphnum = str2num(tp);
 	    } else if (token == WORD) {
 		glyphnum = 0;
 	    } else {
@@ -639,7 +639,7 @@ int shp_loadfont(char *path)
 		fprintf(stderr, "parse error in state %d\n", state);
 		exit(1);
 	    }
-	    numbytes = strtonum(tp);
+	    numbytes = str2num(tp);
 	    if (debug) printf("got numbytes %d\n", numbytes);
 	    state = 3;
 	    break;
@@ -666,7 +666,7 @@ int shp_loadfont(char *path)
 	    break;
 	case 5:
 	    if (token == NUM) {
-	       bytecode[count]=strtonum(tp);
+	       bytecode[count]=str2num(tp);
 	       if (debug) printf("    %d %d %d\n", count, numbytes, bytecode[count]);
 	       count++; 
 	    } else if (token == EOL) {


### PR DESCRIPTION
I received this error while compiling on FreeBSD

```sh
readshpfont.c:97:5: error: conflicting types for 'strtonum'
   97 | int strtonum(char *str) {
      |     ^~~~~~~~
In file included from readshpfont.c:6:
/usr/include/stdlib.h:318:2: note: previous declaration of 'strtonum' was here
  318 |  strtonum(const char *, long long, long long, const char **);
      |  ^~~~~~~~
gmake: *** [<builtin>: readshpfont.o] Error 1
```

Upon further investigation, it looks like all of the BSD's provide a function `strtonum` in their `stdlib.h`.  It is not only a name conflict but also a signature conflict. FreeBSD's `strtonum` [takes 4 arguments](https://www.freebsd.org/cgi/man.cgi?query=strtonum) instead of 1.

Changing `strtonum` to `str2num` fixes this.